### PR TITLE
Added additional fields provided by HubSpot

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -31,6 +31,10 @@ exports.sourceNodes = async ({ boundActionCreators }, configOptions) => {
         notifyRecipients: item.notifyRecipients,
         leadNurturingCampaignId: item.leadNurturingCampaignId,
         formFieldGroups: item.formFieldGroups,
+        metaData: item.metaData,
+        inlineMessage: item.inlineMessage,
+        isPublished: item.isPublished,  
+        thankYouMessageJson: item.thankYouMessageJson,                
         children: [],
         parent: `__SOURCE__`,
         internal: {


### PR DESCRIPTION
Hi - I've just added support for some more fields returned from Hubspot's API.  The metaData field is particularly important because it carries the GDPR / consent compliance form items.