### PR TITLE
remove unused package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,5 @@
   "peerDependencies": {
     "gatsby": ">=3"
   },
-  "dependencies": {
-    "axois": "0.0.1-security"
-  },
   "version": "3.0.0"
 }


### PR DESCRIPTION
This package is not even used but it's marked in security alerts.
Also this probably supposed to be `axios` and not `axois`.

Please check:
https://www.npmjs.com/package/axois