### PR TITLE
change to proper axios package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gatsby": ">=3"
   },
   "dependencies": {
-    "axois": "0.0.1-security"
+    "axios": "^0.21.1"
   },
   "version": "3.0.0"
 }


### PR DESCRIPTION
This is to change axios to use original proper axios package name. 
It was added with typo and this package flag and rise security alerts on pipelines.